### PR TITLE
Feature: Adding order manager and unit test

### DIFF
--- a/src/constants/order_status.py
+++ b/src/constants/order_status.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class OrderStatus(Enum):
+
+    ORDER_PLACED = "order_placed"
+    IN_PROCESS = "in_process"
+    COMPLETED = "completed"
+    CANCELLED = "cancelled"

--- a/src/core/order_manager.py
+++ b/src/core/order_manager.py
@@ -1,0 +1,25 @@
+# order manager mechanism
+
+from queue import Queue
+
+
+class OrderManager:
+    def __init__(self):
+        self._order_status_to_order_queue_map = {
+            "order_placed": Queue(maxsize=0),
+            "in_process": Queue(maxsize=0),
+            "cancelled": Queue(maxsize=0),
+            "completed": Queue(maxsize=0),
+        }
+
+    def add_to_queue(self, order):
+        self._order_status_to_order_queue_map[order.order_status.value].put(order)
+
+    def get_queue_from_status(self, order_status):
+        return self._order_status_to_order_queue_map[order_status].get()
+
+    def get_queue_size(self, order_status):
+        return self._order_status_to_order_queue_map[order_status].qsize()
+
+    def is_order_queue_empty(self, order_status):
+        return self._order_status_to_order_queue_map[order_status].empty()

--- a/src/lib/entities/order.py
+++ b/src/lib/entities/order.py
@@ -7,6 +7,8 @@ class Order:
 
         self.id = None  # integer
         self.order_details = None  # list
+        self.status = None  # enum
+        self.assigned_chef = None  # object
 
     def __eq__(self, other):
         return equals(self, other)

--- a/src/tests/core/order_manager_test.py
+++ b/src/tests/core/order_manager_test.py
@@ -1,0 +1,35 @@
+import unittest
+from src.core.order_manager import OrderManager
+from src.tests.utils.fixtures.order_fixture import build_order
+from src.constants.order_status import OrderStatus
+
+
+class OrderManagerTestCase(unittest.TestCase):
+    def setUp(self):
+        self.order_manager = OrderManager()
+
+    def test_get_from_order_storage(self):
+        order_1 = build_order(order_status=OrderStatus.ORDER_PLACED)
+        order_2 = build_order(order_status=OrderStatus.ORDER_PLACED)
+        order_3 = build_order(order_status=OrderStatus.ORDER_PLACED)
+
+        self.order_manager.add_to_queue(order_1)
+        self.order_manager.add_to_queue(order_2)
+        self.order_manager.add_to_queue(order_3)
+
+        order_pulled = self.order_manager.get_queue_from_status("order_placed")
+        self.assertEqual(order_pulled, order_1)
+
+    def test_get_queue_size(self):
+        order_1 = build_order(order_status=OrderStatus.ORDER_PLACED)
+        order_2 = build_order(order_status=OrderStatus.ORDER_PLACED)
+
+        self.order_manager.add_to_queue(order_1)
+        self.order_manager.add_to_queue(order_2)
+
+        order_placed_storage_size = self.order_manager.get_queue_size("order_placed")
+        self.assertEqual(order_placed_storage_size, 2)
+
+    def test_get_queue_status_empty(self):
+        queue_status = self.order_manager.is_order_queue_empty("order_placed")
+        self.assertTrue(queue_status)

--- a/src/tests/utils/fixtures/order_fixture.py
+++ b/src/tests/utils/fixtures/order_fixture.py
@@ -1,11 +1,13 @@
 from src.lib.entities.order import Order
 
 
-def build_order(order_id=None, order_details=None):
+def build_order(order_id=None, order_details=None, order_status=None, assigned_chef=None):
 
     order = Order()
     order.id = order_id
-    order.ingredients = order_details or []
+    order.order_details = order_details or []
+    order.order_status = order_status
+    order.assigned_chef = assigned_chef
 
     return order
 


### PR DESCRIPTION
* Adding order manager
* Adding order manager unit test

* Description: The order manager will be use to manage the orders status, and will be implement in the kitche simulator for the chefs to take new orders, change order status to "in process" and at the end put the order in an "complete" status. for the differences status the order manager will used queue(placed_order_queue, in_process_order_queue, complete_order_queue, cancel_order_queue).

availables chef will take new orders from the placed_order_queue, they will change order status to in process putting placed orders in the in_process_order_queue while they work in the orders, when the order is complete they will place the order in the complete_order_queue.

the init_order_storage method will be use to create al the queue that the order manager will manage. example: "placed order", "ready to prepate", "preparing", "ready or complete", "cancel".