### PR TITLE
Adding orders to process method and test

### DIFF
--- a/src/api/controllers/order_controller.py
+++ b/src/api/controllers/order_controller.py
@@ -16,3 +16,6 @@ class OrderController:
 
     def update_by_id(self, order_id, order):
         self._order_repository.update_by_id(order_id, order)
+
+    def get_orders_to_process(self):
+        return self._order_repository.get_orders_to_process()

--- a/src/constants/order_status.py
+++ b/src/constants/order_status.py
@@ -1,8 +1,18 @@
 from enum import Enum
 
+"""
+Orders lifecycle:
+
+When an order is create its first status is "new_order", after the order passed through all validations, like 
+ingredient availability validation the order is passed to "order_placed" status,if the order don't passed any of
+the validations the order will pass to "cancelled" status, after that an available chef take the order and change
+its status to "in_process". When the order runs out of preparation time the chef puts the order in "complete"
+status.
+"""
+
 
 class OrderStatus(Enum):
-
+    NEW_ORDER = "new_order"
     ORDER_PLACED = "order_placed"
     IN_PROCESS = "in_process"
     COMPLETED = "completed"

--- a/src/lib/repositories/impl/order_repository_impl.py
+++ b/src/lib/repositories/impl/order_repository_impl.py
@@ -1,6 +1,7 @@
 # This file has the order repository
 
 from src.lib.repositories.order_repository import OrderRepository
+from src.constants.order_status import OrderStatus
 
 
 class OrderRepositoryImpl(OrderRepository):
@@ -25,3 +26,9 @@ class OrderRepositoryImpl(OrderRepository):
     def update_by_id(self, order_id, order):
         current_order = self.get_by_id(order_id)
         current_order.order_details = order.order_details or current_order.order_details
+
+    def get_orders_to_process(self):
+        orders = self.get_all()
+
+        orders_to_process = filter(lambda order: order.status == OrderStatus.NEW_ORDER, orders)
+        return list(orders_to_process)

--- a/src/lib/repositories/order_repository.py
+++ b/src/lib/repositories/order_repository.py
@@ -5,4 +5,6 @@ from src.lib.repositories.generic_repository import GenericRepository
 
 
 class OrderRepository(GenericRepository, metaclass=ABCMeta):
-    pass
+    @staticmethod
+    def get_orders_to_process():
+        pass

--- a/src/tests/api/controllers/order_controller_integration_test.py
+++ b/src/tests/api/controllers/order_controller_integration_test.py
@@ -1,5 +1,6 @@
 import unittest
 from unittest import mock
+from src.constants.order_status import OrderStatus
 
 from src.api.controllers.order_controller import OrderController
 from src.lib.repositories.impl.order_repository_impl import OrderRepositoryImpl
@@ -110,3 +111,17 @@ class OrderRepositoryControllerIntegrationTestCase(unittest.TestCase):
 
         self.assertEqual(len(orders), 2)
         self.assertEqual(updated_order.order_details, order_to_update.order_details)
+
+    def test_get_orders_to_process_successfully(self):
+
+        order_1 = build_order()
+        order_2 = build_order()
+        order_3 = build_order(status=OrderStatus.COMPLETED)
+
+        self.order_controller.add(order_1)
+        self.order_controller.add(order_2)
+        self.order_controller.add(order_3)
+
+        orders_to_process = self.order_controller.get_orders_to_process()
+        self.order_repository.get_orders_to_process.assert_called()
+        self.assertEqual(orders_to_process, [order_1, order_2])

--- a/src/tests/api/controllers/order_controller_test.py
+++ b/src/tests/api/controllers/order_controller_test.py
@@ -49,3 +49,8 @@ class OrderRepositoryControllerTestCase(unittest.TestCase):
         self.order_controller.update_by_id(1, order)
 
         self.order_repository.update_by_id.assert_called_with(1, order)
+
+    def test_get_orders_to_process_successfully(self):
+
+        orders_to_process = self.order_controller.get_orders_to_process()
+        self.order_repository.get_orders_to_process.assert_called()

--- a/src/tests/lib/repositories/impl/order_repository_impl_test.py
+++ b/src/tests/lib/repositories/impl/order_repository_impl_test.py
@@ -3,6 +3,7 @@ import unittest
 from src.lib.repositories.impl.order_repository_impl import OrderRepositoryImpl
 from src.tests.utils.fixtures.order_detail_fixture import build_order_detail
 from src.tests.utils.fixtures.order_fixture import build_order, build_orders
+from src.constants.order_status import OrderStatus
 
 
 class OrderRepositoryImplTestCase(unittest.TestCase):
@@ -105,3 +106,16 @@ class OrderRepositoryImplTestCase(unittest.TestCase):
 
         self.assertEqual(len(orders), 2)
         self.assertEqual(updated_order.order_details, order_to_update.order_details)
+
+    def test_get_orders_to_process(self):
+        order_1 = build_order()
+        order_2 = build_order()
+        order_3 = build_order(order_status=OrderStatus.COMPLETED)
+
+        order_repository = OrderRepositoryImpl()
+        order_repository.add(order_1)
+        order_repository.add(order_2)
+        order_repository.add(order_3)
+
+        self.assertEqual(len(order_repository.get_orders_to_process()), 2)
+


### PR DESCRIPTION
* Adding orders to process method
* Adding order repository test for orders to process method
* Adding order controller unit test for orders to process method
* Adding order controller integration test for orders to process method
* Adding enum class for order status

Orders to process method:

This method will extract all the orders of the order repository and will terminate by the order status wich of the orders are
eligible to be process. in this case the method will filter and return the orders with status "new_order"