### PR TITLE
Refactor: Changing product_ingredient method to get_by_product_id in repo and c…

### DIFF
--- a/src/api/controllers/product_ingredient_controller.py
+++ b/src/api/controllers/product_ingredient_controller.py
@@ -17,5 +17,5 @@ class ProductIngredientController:
     def update_by_id(self, product_ingredient_id, product_ingredient):
         self._product_ingredient_repository.update_by_id(product_ingredient_id, product_ingredient)
 
-    def get_product_ingredients_by_product(self, product):
-        return self._product_ingredient_repository.get_product_ingredients_by_product(product)
+    def get_by_product_id(self, product):
+        return self._product_ingredient_repository.get_by_product_id(product)

--- a/src/lib/repositories/impl/product_ingredient_repository_impl.py
+++ b/src/lib/repositories/impl/product_ingredient_repository_impl.py
@@ -36,7 +36,7 @@ class ProductIngredientRepositoryImpl(ProductIngredientRepository):
             product_ingredient.quantity or current_product_ingredient.quantity
         )
 
-    def get_product_ingredients_by_product(self, product):
+    def get_by_product_id(self, product):
         product_ingredients = self.get_all()
         product_ingredients_of_product = filter(
             (lambda product_ingredient: product.id == product_ingredient.product.id),

--- a/src/lib/repositories/product_ingredient_repository.py
+++ b/src/lib/repositories/product_ingredient_repository.py
@@ -7,5 +7,5 @@ from src.lib.repositories.generic_repository import GenericRepository
 class ProductIngredientRepository(GenericRepository, metaclass=ABCMeta):
 
     @abstractmethod
-    def get_product_ingredients_by_product(self, product):
+    def get_by_product_id(self, product):
         pass

--- a/src/tests/api/controllers/product_ingredient_controller_integration_test.py
+++ b/src/tests/api/controllers/product_ingredient_controller_integration_test.py
@@ -114,7 +114,7 @@ class ProductIngredientRepositoryControllerIntegrationTestCase(unittest.TestCase
         self.assertEqual(len(product_ingredients), 2)
         self.assertEqual(updated_product_ingredient.quantity, product_ingredient_to_update.quantity)
 
-    def test_get_product_ingredients_of_product_from_repository_using_controller(self):
+    def test_get_by_product_id_from_repository_using_controller(self):
         ingredient_1 = build_ingredient(ingredient_id=1, name="test ingredient")
         product_1 = build_product(product_id=1, name="test product")
         product_ingredient_1 = build_product_ingredient(
@@ -126,10 +126,10 @@ class ProductIngredientRepositoryControllerIntegrationTestCase(unittest.TestCase
         self.product_ingredient_controller.add(product_ingredient_2)
 
         product_ingredients_returned = (
-            self.product_ingredient_controller.get_product_ingredients_by_product(
+            self.product_ingredient_controller.get_by_product_id(
                 product_1
             )
         )
-        self.product_ingredient_repository.get_product_ingredients_by_product.assert_called_with(
+        self.product_ingredient_repository.get_by_product_id.assert_called_with(
             product_1
         )

--- a/src/tests/api/controllers/product_ingredient_controller_test.py
+++ b/src/tests/api/controllers/product_ingredient_controller_test.py
@@ -51,10 +51,10 @@ class ProductIngredientRepositoryControllerTestCase(unittest.TestCase):
 
         self.product_ingredient_repository.update_by_id.assert_called_with(1, product_ingredient)
 
-    def test_get_product_ingredients_by_product_successfully(self):
+    def test_get_by_product_id_successfully(self):
         product_ingredient = build_product_ingredient()
         product_1 = build_product()
 
         self.product_ingredient_controller.add(product_ingredient)
-        product_ingredient_returned = self.product_ingredient_controller.get_product_ingredients_by_product(product_1)
-        self.product_ingredient_repository.get_product_ingredients_by_product.assert_called_with(product_1)
+        product_ingredient_returned = self.product_ingredient_controller.get_by_product_id(product_1)
+        self.product_ingredient_repository.get_by_product_id.assert_called_with(product_1)

--- a/src/tests/lib/repositories/impl/product_ingredient_repository_impl_test.py
+++ b/src/tests/lib/repositories/impl/product_ingredient_repository_impl_test.py
@@ -117,7 +117,7 @@ class ProductIngredientRepositoryImplTestCase(unittest.TestCase):
             updated_product_ingredient.quantity, product_ingredient_to_update.quantity
         )
 
-    def test_get_product_ingredients_by_product(self):
+    def test_get_by_product_id_successfully(self):
         product_ingredient_repository = ProductIngredientRepositoryImpl()
         ingredient_1 = build_ingredient(ingredient_id=1, name="test ingredient")
         product_1 = build_product(product_id=1, name="test product")
@@ -129,6 +129,6 @@ class ProductIngredientRepositoryImplTestCase(unittest.TestCase):
         product_ingredient_repository.add(product_ingredient_2)
 
         product_ingredient_returned = (
-            product_ingredient_repository.get_product_ingredients_by_product(product_1)
+            product_ingredient_repository.get_by_product_id(product_1)
         )
         self.assertEqual(product_ingredient_1, product_ingredient_returned[0])


### PR DESCRIPTION
* method **get_products_ingredient_by_product** renamed to **get_by_product_id** to be more consistent.
* The method was rename in the repository, controller and test.