### PR TITLE
Feature: Adding method to get order ingredients by order id

### DIFF
--- a/src/core/ioc.py
+++ b/src/core/ioc.py
@@ -59,9 +59,12 @@ class Ioc:
         self._instance_ioc[
             "inventory_ingredient_repository"
         ] = InventoryIngredientRepositoryImpl()
-        self._instance_ioc["inventory_repository"] = InventoryRepositoryImpl()
-        self._instance_ioc["order_repository"] = OrderRepositoryImpl()
         self._instance_ioc["order_detail_repository"] = OrderDetailRepositoryImpl()
+        self._instance_ioc["inventory_repository"] = InventoryRepositoryImpl()
+        self._instance_ioc["order_repository"] = OrderRepositoryImpl(self._instance_ioc["order_detail_repository"],self._instance_ioc[
+            "product_ingredient_repository"
+        ])
+
         self._instance_ioc["chef_repository"] = ChefRepositoryImpl()
 
         self._instance_ioc[

--- a/src/lib/repositories/impl/order_repository_impl.py
+++ b/src/lib/repositories/impl/order_repository_impl.py
@@ -5,9 +5,13 @@ from src.constants.order_status import OrderStatus
 
 
 class OrderRepositoryImpl(OrderRepository):
-    def __init__(self):
+    def __init__(
+        self, order_detail_repository=None, product_ingredient_repository=None
+    ):
         self._orders = {}
         self._current_id = 1
+        self.order_detail_repository = order_detail_repository
+        self.product_ingredient_repository = product_ingredient_repository
 
     def add(self, order):
         order.id = self._current_id
@@ -30,5 +34,18 @@ class OrderRepositoryImpl(OrderRepository):
     def get_orders_to_process(self):
         orders = self.get_all()
 
-        orders_to_process = filter(lambda order: order.status == OrderStatus.NEW_ORDER, orders)
+        orders_to_process = filter(
+            lambda order: order.status == OrderStatus.NEW_ORDER, orders
+        )
         return list(orders_to_process)
+
+    def get_order_ingredients_by_order_id(self, order_id):
+
+        order_details = self.order_detail_repository.get_by_order_id(order_id)
+        product_ids = [order_detail.product_id for order_detail in order_details]
+        filtered_product_ingredients = (
+            self.product_ingredient_repository.get_product_ingredients_by_product_ids(
+                product_ids
+            )
+        )
+        return filtered_product_ingredients

--- a/src/lib/repositories/impl/product_ingredient_repository_impl.py
+++ b/src/lib/repositories/impl/product_ingredient_repository_impl.py
@@ -43,3 +43,13 @@ class ProductIngredientRepositoryImpl(ProductIngredientRepository):
             product_ingredients,
         )
         return list(product_ingredients_of_product)
+
+    def get_product_ingredients_by_product_ids(self, product_ids):
+
+        product_ingredients = self.get_all()
+        filtered_product_ingredients = filter(
+            (lambda product_ingredient: product_ingredient.product_id in product_ids),
+            product_ingredients,
+        )
+
+        return list(filtered_product_ingredients)

--- a/src/lib/repositories/order_repository.py
+++ b/src/lib/repositories/order_repository.py
@@ -8,3 +8,7 @@ class OrderRepository(GenericRepository, metaclass=ABCMeta):
     @staticmethod
     def get_orders_to_process():
         pass
+
+    @staticmethod
+    def get_order_ingredients_by_order_id(self, order_id):
+        pass

--- a/src/lib/repositories/product_ingredient_repository.py
+++ b/src/lib/repositories/product_ingredient_repository.py
@@ -5,7 +5,10 @@ from src.lib.repositories.generic_repository import GenericRepository
 
 
 class ProductIngredientRepository(GenericRepository, metaclass=ABCMeta):
-
     @abstractmethod
     def get_by_product_id(self, product_id):
+        pass
+
+    @abstractmethod
+    def get_product_ingredients_by_product_ids(self, product_ids):
         pass

--- a/src/tests/lib/repositories/impl/order_repository_impl_test.py
+++ b/src/tests/lib/repositories/impl/order_repository_impl_test.py
@@ -1,8 +1,18 @@
 import unittest
+from unittest import mock
 
+from src.lib.repositories.impl.order_detail_repository_impl import (
+    OrderDetailRepositoryImpl,
+)
 from src.lib.repositories.impl.order_repository_impl import OrderRepositoryImpl
+from src.lib.repositories.impl.product_ingredient_repository_impl import (
+    ProductIngredientRepositoryImpl,
+)
 from src.tests.utils.fixtures.order_detail_fixture import build_order_detail
 from src.tests.utils.fixtures.order_fixture import build_order, build_orders
+from src.tests.utils.fixtures.ingredient_fixture import build_ingredient
+from src.tests.utils.fixtures.product_ingredient_fixture import build_product_ingredient
+from src.tests.utils.fixtures.product_fixture import build_product
 from src.constants.order_status import OrderStatus
 
 
@@ -119,3 +129,40 @@ class OrderRepositoryImplTestCase(unittest.TestCase):
 
         self.assertEqual(len(order_repository.get_orders_to_process()), 2)
 
+    def test_get_order_ingredients_by_order_id(self):
+        product_ingredient_repository = mock.Mock(
+            wraps=ProductIngredientRepositoryImpl()
+        )
+        order_detail_repository = mock.Mock(wraps=OrderDetailRepositoryImpl())
+        ingredient_1 = build_ingredient(ingredient_id=1, name="ingredient_1")
+        ingredient_2 = build_ingredient(ingredient_id=2, name="ingredient_2")
+        product_1 = build_product(product_id=1, name="product_1")
+        product_ingredient_1 = build_product_ingredient(
+            id=1, product_id=product_1.id, ingredient_id=ingredient_1.id, quantity=2
+        )
+        product_ingredient_repository.add(product_ingredient_1)
+
+        product_ingredient_2 = build_product_ingredient(
+            id=2, product_id=product_1.id, ingredient_id=ingredient_2.id, quantity=2
+        )
+        product_ingredient_repository.add(product_ingredient_2)
+
+        order_1 = build_order(order_id=1)
+        order_detail_1 = build_order_detail(
+            order_detail_id=1, order_id=order_1.id, product_id=product_1.id, quantity=1
+        )
+        order_detail_repository.add(order_detail_1)
+        order_repository = OrderRepositoryImpl(
+            order_detail_repository, product_ingredient_repository
+        )
+        order_ingredients = order_repository.get_order_ingredients_by_order_id(
+            order_1.id
+        )
+        product_ingredient_repository.get_product_ingredients_by_product_ids.assert_called_with(
+            [product_1.id]
+        )
+        order_detail_repository.get_by_order_id.assert_called_with(order_1.id)
+
+        self.assertEqual(
+            order_ingredients, [product_ingredient_1, product_ingredient_2]
+        )


### PR DESCRIPTION
* Method to get order ingredients by order id

This method will get the ingredients of an order by its id. with the order id it will get all the order_detail(product) associate with that id calling the method inside order_detail_repository **get_by_order_id** , after get the order details we can get the product_ingredients(ingredient of a product with its quantity needed) looping the order_details. 

It is important to highlight that the order_detail_repository and product_ingredient_repository must be sent in the constructor of the order_repository  to be able to do all the operations.
