### PR TITLE
Feature:"Adding method to get the product qty from qty of ingredients in the i…

### DIFF
--- a/src/core/ioc.py
+++ b/src/core/ioc.py
@@ -58,12 +58,15 @@ class Ioc:
         self._instance_ioc["ingredient_repository"] = IngredientRepositoryImpl()
         self._instance_ioc[
             "inventory_ingredient_repository"
-        ] = InventoryIngredientRepositoryImpl()
+        ] = InventoryIngredientRepositoryImpl(
+            self._instance_ioc["product_ingredient_repository"]
+        )
         self._instance_ioc["order_detail_repository"] = OrderDetailRepositoryImpl()
         self._instance_ioc["inventory_repository"] = InventoryRepositoryImpl()
-        self._instance_ioc["order_repository"] = OrderRepositoryImpl(self._instance_ioc["order_detail_repository"],self._instance_ioc[
-            "product_ingredient_repository"
-        ])
+        self._instance_ioc["order_repository"] = OrderRepositoryImpl(
+            self._instance_ioc["order_detail_repository"],
+            self._instance_ioc["product_ingredient_repository"],
+        )
 
         self._instance_ioc["chef_repository"] = ChefRepositoryImpl()
         self._instance_ioc["chef_repository"] = ChefRepositoryImpl(

--- a/src/lib/repositories/impl/inventory_ingredient_repository_impl.py
+++ b/src/lib/repositories/impl/inventory_ingredient_repository_impl.py
@@ -1,4 +1,7 @@
 # This file has the inventory ingredient repository impl
+from src.utils.inventory_ingredient_util import (
+    setup_products_qty_array_to_final_products_qty_map,
+)
 
 from src.lib.repositories.inventory_ingredient_repository import (
     InventoryIngredientRepository,
@@ -6,10 +9,11 @@ from src.lib.repositories.inventory_ingredient_repository import (
 
 
 class InventoryIngredientRepositoryImpl(InventoryIngredientRepository):
-    def __init__(self):
+    def __init__(self, product_ingredient_repository=None):
 
         self._inventory_ingredients = {}
         self._current_id = 1
+        self.product_ingredient_repository = product_ingredient_repository
 
     def add(self, inventory_ingredient):
         inventory_ingredient.id = self._current_id
@@ -69,3 +73,18 @@ class InventoryIngredientRepositoryImpl(InventoryIngredientRepository):
         if ingredient_to_validate[0].ingredient_quantity > quantity_to_use:
             return True
         return False
+
+    def get_final_product_qty_by_product_ids(self, product_ids):
+
+        reduce_products_qty_array_to_final_products_qty_map = (
+            setup_products_qty_array_to_final_products_qty_map(
+                self.get_by_ingredient_id,
+                self.product_ingredient_repository.get_by_product_id,
+            )
+        )
+
+        final_product_possible_qty_map = (
+            reduce_products_qty_array_to_final_products_qty_map(product_ids)
+        )
+
+        return final_product_possible_qty_map

--- a/src/lib/repositories/inventory_ingredient_repository.py
+++ b/src/lib/repositories/inventory_ingredient_repository.py
@@ -10,6 +10,11 @@ class InventoryIngredientRepository(GenericRepository, metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def validate_ingredient_availability(self, inventory_id, ingredient_id, quantity_to_use):
+    def validate_ingredient_availability(
+        self, inventory_id, ingredient_id, quantity_to_use
+    ):
         pass
 
+    @abstractmethod
+    def get_final_product_qty_by_product_ids(self, product_ids):
+        pass

--- a/src/tests/utils/inventory_ingredient_util_test.py
+++ b/src/tests/utils/inventory_ingredient_util_test.py
@@ -1,0 +1,101 @@
+import unittest
+from unittest.mock import Mock, patch
+
+from src.tests.utils.fixtures.ingredient_fixture import build_ingredient
+from src.tests.utils.fixtures.inventory_ingredient_fixture import (
+    build_inventory_ingredient,
+)
+from src.tests.utils.fixtures.product_ingredient_fixture import build_product_ingredient
+from src.utils.inventory_ingredient_util import (
+    products_qty_by_ingredients_qty_reducer,
+    products_qty_array_to_final_products_qty_map_reducer,
+    setup_products_qty_array_to_final_products_qty_map,
+)
+
+
+def get_inventory_ingredient_by_ingredient_id_mock(ingredient_id):
+
+    inventory_ingredient_1 = build_inventory_ingredient(
+        inventory_ingredient_id=1, ingredient_id=1, ingredient_quantity=20
+    )
+    inventory_ingredient_2 = build_inventory_ingredient(
+        inventory_ingredient_id=2, ingredient_id=2, ingredient_quantity=30
+    )
+    inventory_ingredients = {1: inventory_ingredient_1, 2: inventory_ingredient_2}
+    return [inventory_ingredients[ingredient_id]]
+
+
+def get_product_ingredient_by_product_id_mock(product_id):
+    product_ingredient_1 = build_product_ingredient(
+        id=1, product_id=1, ingredient_id=1, quantity=2
+    )
+    product_ingredient_2 = build_product_ingredient(
+        id=2, product_id=2, ingredient_id=2, quantity=4
+    )
+    product_ingredients = {1: product_ingredient_1, 2: product_ingredient_2}
+    return [product_ingredients[product_id]]
+
+
+class TestInventoryIngredient(unittest.TestCase):
+    def test_quantity_ingredients_by_product_reducer(self):
+        ingredient = build_ingredient(ingredient_id=1, name="ingredient test")
+        product_ingredient = build_product_ingredient(
+            id=1, ingredient_id=ingredient.id, quantity=2
+        )
+        inventory_ingredient = build_inventory_ingredient(
+            inventory_ingredient_id=1, ingredient_id=1, ingredient_quantity=20
+        )
+
+        quantity_ingredients_to_prepare_product = (
+            products_qty_by_ingredients_qty_reducer(
+                [], product_ingredient, [inventory_ingredient]
+            )
+        )
+        self.assertEqual(quantity_ingredients_to_prepare_product[0], 10)
+
+    def test_products_qty_array_to_final_products_qty_map_reducer(self):
+        ingredient = build_ingredient(ingredient_id=1, name="ingredient test")
+        product_ingredient = build_product_ingredient(
+            id=1, ingredient_id=ingredient.id, quantity=2
+        )
+        inventory_ingredient = build_inventory_ingredient(
+            inventory_ingredient_id=1, ingredient_id=1, ingredient_quantity=20
+        )
+
+        quantity_ingredients_to_prepare_product = (
+            products_qty_by_ingredients_qty_reducer(
+                [], product_ingredient, [inventory_ingredient]
+            )
+        )
+
+        final_product_qty_result_map = (
+            products_qty_array_to_final_products_qty_map_reducer(
+                {},
+                product_ingredient.product_id,
+                quantity_ingredients_to_prepare_product,
+            )
+        )
+        self.assertEqual(
+            final_product_qty_result_map[product_ingredient.product_id], 10
+        )
+
+    def test_setup_products_qty_array_to_final_products_qty_map(self):
+
+        mocked_get_inventory_ingredient_by_ingredient_id_mock = Mock(
+            wraps=get_inventory_ingredient_by_ingredient_id_mock
+        )
+        mocked_get_product_ingredient_by_product_id_mock = Mock(
+            wraps=get_product_ingredient_by_product_id_mock
+        )
+        reduce_products_qty_array_to_final_products_qty_map = (
+            setup_products_qty_array_to_final_products_qty_map(
+                mocked_get_inventory_ingredient_by_ingredient_id_mock,
+                mocked_get_product_ingredient_by_product_id_mock,
+            )
+        )
+        product_possible_qty_quantity = (
+            reduce_products_qty_array_to_final_products_qty_map([1])
+        )
+        self.assertEqual(product_possible_qty_quantity[1], 10)
+        mocked_get_inventory_ingredient_by_ingredient_id_mock.assert_called_with(1)
+        mocked_get_product_ingredient_by_product_id_mock.assert_called_with(1)

--- a/src/utils/inventory_ingredient_util.py
+++ b/src/utils/inventory_ingredient_util.py
@@ -1,0 +1,55 @@
+from functools import reduce
+
+
+def products_qty_by_ingredients_qty_reducer(
+    quantity_ingredients_result, product_ingredient, inventory_ingredient
+):
+    """
+    Reducer function to get a list of quantity of ingredient to make a product by divided the quantity in the inventory
+    divided by the quantity that the product needs
+    """
+    quantity_ingredients_result.append(
+        inventory_ingredient[0].ingredient_quantity / product_ingredient.quantity
+    )
+    return quantity_ingredients_result
+
+
+def products_qty_array_to_final_products_qty_map_reducer(
+    final_product_qty_result, product_id, qty_ingredient_by_product_list_reducer
+):
+
+    final_product_qty_result[product_id] = min(qty_ingredient_by_product_list_reducer)
+
+    return final_product_qty_result
+
+
+def setup_products_qty_array_to_final_products_qty_map(
+    get_inventory_ingredient_by_ingredient_id, get_product_ingredient_by_product_id
+):
+    def reduce_products_qty_by_ingredients_qty(product_id):
+        return reduce(
+            lambda quantity_ingredients_result, product_ingredient: products_qty_by_ingredients_qty_reducer(
+                quantity_ingredients_result,
+                product_ingredient,
+                get_inventory_ingredient_by_ingredient_id(
+                    product_ingredient.ingredient_id
+                ),
+            ),
+            get_product_ingredient_by_product_id(product_id),
+            [],
+        )
+
+    def reduce_products_qty_array_to_final_products_qty_map(product_ids):
+        return reduce(
+            lambda final_product_qty_result, product_id: products_qty_array_to_final_products_qty_map_reducer(
+                final_product_qty_result,
+                product_id,
+                reduce_products_qty_by_ingredients_qty(
+                    product_id,
+                ),
+            ),
+            product_ids,
+            {},
+        )
+
+    return reduce_products_qty_array_to_final_products_qty_map


### PR DESCRIPTION
*Adding method to get the quantity of products that can be made from ingredients in the inventory.

This method from a product_ids list will return a map of product id keys and quantity of products that can be made value.

the method will evaluate the ingredient need to made a product will the lowest quantity on the inventory to determine the quantity of products that can be made.

example:

if we want to know how many hamburger can be made from ingredients in the inventory:

hamburguer ingredients:

qty    ingredient
2        cheese
2        bread
1        meat
2       tomatoes
2      bacon

inventory ingredients:

qty      ingredient
100       cheese
100       bread
50         meat
100       tomato
20         bacon

if we dived the ingredients in the invetory divided by product ingredient we get the next result:

cheese 100/2 = 50
bread   100/2 = 50
meat     50/2  = 25
tomato 100/2 = 50
bacon    20/2 = 10

as bacon is the lowes ingredient in the inventory it means that the quantity of hamburger that can be made are 10.