### PR TITLE
alter order table to set nullables as true in assigned_chef_id column

### DIFF
--- a/src/migrations/versions/e96d49093b33_alter_order_table.py
+++ b/src/migrations/versions/e96d49093b33_alter_order_table.py
@@ -1,0 +1,26 @@
+"""alter order table
+
+Revision ID: e96d49093b33
+Revises: 3d244de0f7a2
+Create Date: 2022-09-07 08:35:44.793146
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "e96d49093b33"
+down_revision = "3d244de0f7a2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column("orders", "assigned_chef_id", nullable=True)
+
+    op.execute("Update orders SET assigned_chef_id = NULL")
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
* alter order tabla to set nulable true in assigned_chef_id column
* updating assigned_chef_id column with NULL values.

This updating is a fix to assigned_chef_id column as new orders with not chef assigned have to be null to know that this orders are wating to be worked.