### PR TITLE
adding method to add new orders to queue from db

### DIFF
--- a/src/constants/audit.py
+++ b/src/constants/audit.py
@@ -7,5 +7,5 @@ class Status(Enum):
 
 
 class InternalUsers(Enum):
-    SEEDER = -1
-    KITCHEN_SIMULATOR = -2
+    SEEDER = 1
+    KITCHEN_SIMULATOR = 2

--- a/src/core/engine/app_engine_processor.py
+++ b/src/core/engine/app_engine_processor.py
@@ -1,18 +1,30 @@
 # thread manager
 
-from src.core.engine.app_engine_processor_context import \
-    AppEngineProcessorContext
+from src.core.engine.app_engine_processor_context import AppEngineProcessorContext
 from src.core.engine.app_processor_config import AppProcessorConfig
-from src.core.engine.processors.kitchen_simulator import KitchenSimulator
+from src.core.engine.processors.kitchen_simulator import (
+    KitchenSimulator,
+    initialize_kitchen_simulator,
+)
+from src.core.ioc import get_ioc_instance
+from src.core.order_manager import OrderManager
 
 
 class AppEngineProcessor:
     def __init__(self):
-        kitchen_simulator_config = AppProcessorConfig("kitchen_simulator_test", 0.2)
+        ioc = get_ioc_instance()
+        kitchen_simulator_config = AppProcessorConfig(
+            id="kitchen_simulator_test",
+            interval=0.2,
+            order_manager=OrderManager(),
+            on_start=initialize_kitchen_simulator,
+        )
         kitchen_simulator = KitchenSimulator(kitchen_simulator_config)
-        self.app_context = AppEngineProcessorContext(processors=[kitchen_simulator])
+        self.app_context = AppEngineProcessorContext(
+            processors=[kitchen_simulator], ioc=ioc
+        )
 
-        kitchen_simulator.app_context = self.app_context
+        kitchen_simulator.set_app_context(self.app_context)
 
     # method to Start thread process
     def start(self):

--- a/src/core/engine/app_engine_processor_context.py
+++ b/src/core/engine/app_engine_processor_context.py
@@ -1,3 +1,4 @@
 class AppEngineProcessorContext:
-    def __init__(self, processors=None):
+    def __init__(self, processors=None, ioc=None):
         self.processors = processors
+        self.ioc = ioc

--- a/src/core/engine/app_processor_config.py
+++ b/src/core/engine/app_processor_config.py
@@ -7,6 +7,7 @@ class AppProcessorConfig:
         on_destroy=None,
         before_execute=None,
         after_execute=None,
+        order_manager=None,
     ):
         self.id = id
         self.interval = interval
@@ -14,3 +15,4 @@ class AppProcessorConfig:
         self.on_destroy = on_destroy
         self.before_execute = before_execute
         self.after_execute = after_execute
+        self.order_manager = order_manager

--- a/src/core/engine/processors/abstract_processor.py
+++ b/src/core/engine/processors/abstract_processor.py
@@ -18,6 +18,7 @@ class AbstractProcessor(Thread):
         pass
 
     def run(self):
+
         if self.app_processor_config.on_start:
             self.app_processor_config.on_start(
                 self.app_processor_config, self.app_context

--- a/src/core/engine/processors/kitchen_simulator.py
+++ b/src/core/engine/processors/kitchen_simulator.py
@@ -4,10 +4,39 @@ from datetime import datetime, timedelta
 from src.constants.audit import InternalUsers
 from src.constants.order_status import OrderStatus
 from src.core.engine.processors.abstract_processor import AbstractProcessor
-from src.core.ioc import get_ioc_instance
 from src.core.order_manager import ORDER_QUEUE_STATUS_TO_CHUNK_LIMIT_MAP
 from src.utils.order_util import compute_order_estimated_time
 from src.utils.time_util import get_unix_time_stamp_milliseconds
+
+
+def initialize_kitchen_simulator(app_processor_config, app_context):
+    ioc = app_context.ioc
+    order_controller = ioc.get_instance("order_controller")
+    order_manager = app_processor_config.order_manager
+
+    load_order_into_order_manager(
+        order_manager, order_controller, OrderStatus.NEW_ORDER
+    )
+    load_order_into_order_manager(
+        order_manager, order_controller, OrderStatus.IN_PROCESS
+    )
+    load_order_into_order_manager(
+        order_manager, order_controller, OrderStatus.COMPLETED
+    )
+    load_order_into_order_manager(
+        order_manager, order_controller, OrderStatus.CANCELLED
+    )
+
+
+def load_order_into_order_manager(order_manager, order_controller, order_status):
+    orders = order_controller.get_orders_by_status(
+        order_status.name,
+        order_limit=ORDER_QUEUE_STATUS_TO_CHUNK_LIMIT_MAP[order_status],
+    )
+
+    if orders:
+        for order in orders:
+            order_manager.add_to_queue(order)
 
 
 class KitchenSimulator(AbstractProcessor, metaclass=ABCMeta):
@@ -15,19 +44,24 @@ class KitchenSimulator(AbstractProcessor, metaclass=ABCMeta):
         super().__init__(
             app_processor_config=app_processor_config, app_context=app_context
         )
+        self._process_clean_queues_delta_time_sum = 0  # float
+        self._process_clean_queues_timeout = 60  # seconds
+        self.order_manager = None
+        self.chef_controller = None
+        self.order_status_history_controller = None
+        self.order_controller = None
 
-        ioc = get_ioc_instance()
+    def set_app_context(self, app_context):
+        ioc = app_context.ioc
         self.order_controller = ioc.get_instance("order_controller")
         self.order_status_history_controller = ioc.get_instance(
             "order_status_history_controller"
         )
         self.chef_controller = ioc.get_instance("chef_controller")
-        self.order_manager = ioc.get_instance("order_manager")
-        self._process_clean_queues_timeout = 60  # seconds
-        self._process_clean_queues_delta_time_sum = 0  # float
+        self.order_manager = self.app_processor_config.order_manager
+        self.app_context = app_context
 
     def process(self, delta_time):
-
         self.process_new_orders()
         self.process_orders_in_process()
         self.process_clean_queues(delta_time)
@@ -35,7 +69,7 @@ class KitchenSimulator(AbstractProcessor, metaclass=ABCMeta):
     def process_new_orders(self):
 
         orders_to_process = self.order_controller.get_orders_by_status(
-            OrderStatus.NEW_ORDER,
+            OrderStatus.NEW_ORDER.name,
             order_limit=ORDER_QUEUE_STATUS_TO_CHUNK_LIMIT_MAP[OrderStatus.NEW_ORDER],
         )
         orders_validation_map = self.order_controller.get_validated_orders_map(
@@ -46,7 +80,7 @@ class KitchenSimulator(AbstractProcessor, metaclass=ABCMeta):
         if available_chef_ids:
 
             order_in_turn_id = self.order_manager.get_queue_from_status(
-                OrderStatus.NEW_ORDER
+                OrderStatus.NEW_ORDER.name
             )
 
             if order_in_turn_id:
@@ -67,7 +101,7 @@ class KitchenSimulator(AbstractProcessor, metaclass=ABCMeta):
     def process_orders_in_process(self):
 
         order_id_to_be_checked = self.order_manager.get_queue_from_status(
-            OrderStatus.IN_PROCESS
+            OrderStatus.IN_PROCESS.name
         )
 
         if order_id_to_be_checked:
@@ -113,7 +147,7 @@ class KitchenSimulator(AbstractProcessor, metaclass=ABCMeta):
     ):
         order_to_be_assign.assigned_chef_id = available_chef_id
         print(f"chef {available_chef_id} assigned to order {order_to_be_assign.id}")
-        order_to_be_assign.status = OrderStatus.IN_PROCESS
+        order_to_be_assign.status = OrderStatus.IN_PROCESS.name
         self.order_controller.reduce_order_ingredients_from_inventory(
             order_to_be_assign.id
         )
@@ -126,7 +160,7 @@ class KitchenSimulator(AbstractProcessor, metaclass=ABCMeta):
         print(f"order {order_to_be_assign.id} in process at {datetime.now()}")
 
     def _order_send_to_cancel(self, order_to_be_cancel):
-        order_to_be_cancel.status = OrderStatus.CANCELLED
+        order_to_be_cancel.status = OrderStatus.CANCELLED.name
         self.order_controller.update_by_id(order_to_be_cancel.id, order_to_be_cancel)
         self.order_status_history_controller.set_next_status_history_by_order_id(
             order_to_be_cancel.id, order_to_be_cancel.status
@@ -135,7 +169,7 @@ class KitchenSimulator(AbstractProcessor, metaclass=ABCMeta):
         print(f"order {order_to_be_cancel.id} cancelled at {datetime.now()}")
 
     def _order_send_to_complete(self, order_to_be_complete):
-        order_to_be_complete.status = OrderStatus.COMPLETED
+        order_to_be_complete.status = OrderStatus.COMPLETED.name
         self.order_controller.update_by_id(
             order_to_be_complete.id, order_to_be_complete
         )

--- a/src/core/order_manager.py
+++ b/src/core/order_manager.py
@@ -15,16 +15,16 @@ ORDER_QUEUE_STATUS_TO_CHUNK_LIMIT_MAP = {
 class OrderManager:
     def __init__(self):
         self._order_status_to_order_queue_map = {
-            OrderStatus.NEW_ORDER: PriorityQueue(
+            OrderStatus.NEW_ORDER.name: PriorityQueue(
                 maxsize=ORDER_QUEUE_STATUS_TO_CHUNK_LIMIT_MAP[OrderStatus.NEW_ORDER]
             ),
-            OrderStatus.IN_PROCESS: PriorityQueue(
+            OrderStatus.IN_PROCESS.name: PriorityQueue(
                 maxsize=ORDER_QUEUE_STATUS_TO_CHUNK_LIMIT_MAP[OrderStatus.IN_PROCESS]
             ),
-            OrderStatus.CANCELLED: PriorityQueue(
+            OrderStatus.CANCELLED.name: PriorityQueue(
                 maxsize=ORDER_QUEUE_STATUS_TO_CHUNK_LIMIT_MAP[OrderStatus.CANCELLED]
             ),
-            OrderStatus.COMPLETED: PriorityQueue(
+            OrderStatus.COMPLETED.name: PriorityQueue(
                 maxsize=ORDER_QUEUE_STATUS_TO_CHUNK_LIMIT_MAP[OrderStatus.COMPLETED]
             ),
         }
@@ -48,7 +48,7 @@ class OrderManager:
 
     def clean_queues_with_full_storage(self, limit_value_before_clean=500):
 
-        for status in [OrderStatus.COMPLETED, OrderStatus.CANCELLED]:
+        for status in [OrderStatus.COMPLETED.name, OrderStatus.CANCELLED.name]:
             if self.get_queue_size(status) > limit_value_before_clean:
                 for _ in range(100):
                     deque_id = self.get_queue_from_status(status)

--- a/src/lib/entities/product_ingredient.py
+++ b/src/lib/entities/product_ingredient.py
@@ -9,7 +9,7 @@ class ProductIngredient(AbstractEntity):
         self.product_id = None  # integer
         self.ingredient_id = None  # integer
         self.quantity = None  # integer
-        self.ingredient_type = None  # string
+        self.cooking_type = None  # string
 
     def __eq__(self, other):
         return equals(self, other)

--- a/src/scripts/seeder.sql
+++ b/src/scripts/seeder.sql
@@ -554,28 +554,64 @@ BEGIN
        order_status:='NEW_ORDER',
     order_created_by:=1
   ); 
- 
-  CALL insert_order_with_defaults(
-       order_status:='NEW_ORDER',
-    order_created_by:=1
-  ); 
- 
-  CALL insert_order_with_defaults(
-       order_status:='NEW_ORDER',
-    order_created_by:=1
-  ); 
- 
-  CALL insert_order_with_defaults(
-       order_status:='NEW_ORDER',
-    order_created_by:=1
-  ); 
+
+  CALL insert_order_status_history_with_defaults(
+    order_status_history_order_id:=1,
+        order_status_history_to_time:=NULL ,
+    order_status_history_from_status:='NEW_ORDER',
+      order_status_history_to_status:=NULL
+  );
  
   CALL insert_order_with_defaults(
        order_status:='NEW_ORDER',
     order_created_by:=1
   );
  
-
+  CALL insert_order_status_history_with_defaults(
+    order_status_history_order_id:=2,
+        order_status_history_to_time:=NULL ,
+    order_status_history_from_status:='NEW_ORDER',
+      order_status_history_to_status:=NULL
+  );
+ 
+  CALL insert_order_with_defaults(
+       order_status:='NEW_ORDER',
+    order_created_by:=1
+  );
+  
+  CALL insert_order_status_history_with_defaults(
+    order_status_history_order_id:=3,
+        order_status_history_to_time:=NULL ,
+    order_status_history_from_status:='NEW_ORDER',
+      order_status_history_to_status:=NULL
+  );
+ 
+  CALL insert_order_with_defaults(
+       order_status:='NEW_ORDER',
+    order_created_by:=1
+  );
+ 
+  CALL insert_order_status_history_with_defaults(
+    order_status_history_order_id:=4,
+        order_status_history_to_time:=NULL ,
+    order_status_history_from_status:='NEW_ORDER',
+      order_status_history_to_status:=NULL
+  );
+  
+ 
+  CALL insert_order_with_defaults(
+       order_status:='NEW_ORDER',
+    order_created_by:=1
+  );
+ 
+  CALL insert_order_status_history_with_defaults(
+    order_status_history_order_id:=5,
+        order_status_history_to_time:=NULL ,
+    order_status_history_from_status:='NEW_ORDER',
+      order_status_history_to_status:=NULL
+  );
+  
+ 
   CALL insert_order_detail_with_defaults(
       order_detail_order_id:=1,
     order_detail_product_id:=1,

--- a/src/tests/core/engine/processors/kitchen_simulator_integration_test.py
+++ b/src/tests/core/engine/processors/kitchen_simulator_integration_test.py
@@ -60,7 +60,7 @@ class KitchenSimulatorIntegrationTest(TestCase):
             ingredient_id=ingredient_1.id,
             product_id=product_1.id,
             quantity=6,
-            ingredient_type=CookingType.FRYING,
+            cooking_type=CookingType.FRYING.name,
         )
 
         order_1 = build_order(order_id=1, status=OrderStatus.NEW_ORDER)
@@ -155,7 +155,7 @@ class KitchenSimulatorIntegrationTest(TestCase):
             ingredient_id=ingredient_2.id,
             product_id=product_2.id,
             quantity=1,
-            ingredient_type=CookingType.FRYING,
+            cooking_type=CookingType.FRYING,
         )
 
         order_3 = build_order(order_id=3, status=OrderStatus.NEW_ORDER)

--- a/src/tests/core/engine/processors/kitchen_simulator_test.py
+++ b/src/tests/core/engine/processors/kitchen_simulator_test.py
@@ -1,7 +1,7 @@
 import unittest
 from datetime import datetime
 from unittest import mock
-
+from src.core.order_manager import ORDER_QUEUE_STATUS_TO_CHUNK_LIMIT_MAP
 from src.constants.cooking_type import CookingType
 from src.constants.order_status import OrderStatus
 from src.core.engine.processors.kitchen_simulator import KitchenSimulator
@@ -32,14 +32,14 @@ class KitchenSimulatorTest(unittest.TestCase):
     ):
 
         chef_1 = build_chef(chef_id=1)
-        order_1 = build_order(order_id=1, status=OrderStatus.NEW_ORDER)
+        order_1 = build_order(order_id=1, status=OrderStatus.NEW_ORDER.name)
 
         self.kitchen_simulator.order_controller.get_orders_by_status.return_value = [
             order_1
         ]
         self.kitchen_simulator.order_controller.get_order_ingredients_by_order_id.return_value = [
             build_product_ingredient(
-                product_ingredient_id=1, quantity=1, ingredient_type=CookingType.FRYING
+                product_ingredient_id=1, quantity=1, cooking_type=CookingType.FRYING.name
             )
         ]
         self.kitchen_simulator.chef_controller.get_available_chefs.return_value = [
@@ -54,7 +54,7 @@ class KitchenSimulatorTest(unittest.TestCase):
         )
         self.kitchen_simulator.process_new_orders()
         self.kitchen_simulator.order_controller.get_orders_by_status.assert_called_with(
-            OrderStatus.NEW_ORDER, order_limit=1000
+            OrderStatus.NEW_ORDER.name, order_limit=ORDER_QUEUE_STATUS_TO_CHUNK_LIMIT_MAP[OrderStatus.NEW_ORDER]
         )
         self.kitchen_simulator.order_controller.get_validated_orders_map.assert_called_with(
             [order_1]
@@ -62,18 +62,18 @@ class KitchenSimulatorTest(unittest.TestCase):
 
         self.kitchen_simulator.chef_controller.get_available_chefs.assert_called()
         self.kitchen_simulator.order_manager.get_queue_from_status.assert_called_with(
-            OrderStatus.NEW_ORDER
+            OrderStatus.NEW_ORDER.name
         )
         arg_with_method_was_called = (
             self.kitchen_simulator.order_manager._mock_mock_calls[1][1]
         )
-        self.assertEqual(arg_with_method_was_called[0].status, OrderStatus.IN_PROCESS)
+        self.assertEqual(arg_with_method_was_called[0].status, OrderStatus.IN_PROCESS.name)
         mocked_order_estimated_time.asser_called_with(
             [
                 build_product_ingredient(
                     product_ingredient_id=1,
                     quantity=1,
-                    ingredient_type=CookingType.FRYING,
+                    cooking_type=CookingType.FRYING.name,
                 )
             ],
             chef_1,
@@ -84,7 +84,7 @@ class KitchenSimulatorTest(unittest.TestCase):
 
     def test_assign_orders_to_available_chefs_when_order_is_not_valid(self):
         chef_1 = build_chef(chef_id=1)
-        order_1 = build_order(order_id=1, status=OrderStatus.NEW_ORDER)
+        order_1 = build_order(order_id=1, status=OrderStatus.NEW_ORDER.name)
 
         self.kitchen_simulator.order_controller.get_orders_by_status.return_value = [
             order_1
@@ -100,19 +100,19 @@ class KitchenSimulatorTest(unittest.TestCase):
         )
         self.kitchen_simulator.process_new_orders()
         self.kitchen_simulator.order_controller.get_orders_by_status.assert_called_with(
-            OrderStatus.NEW_ORDER, order_limit=1000
+            OrderStatus.NEW_ORDER.name, order_limit=ORDER_QUEUE_STATUS_TO_CHUNK_LIMIT_MAP[OrderStatus.NEW_ORDER]
         )
         self.kitchen_simulator.order_controller.get_validated_orders_map.assert_called_with(
             [order_1]
         )
         self.kitchen_simulator.chef_controller.get_available_chefs.assert_called()
         self.kitchen_simulator.order_manager.get_queue_from_status.assert_called_with(
-            OrderStatus.NEW_ORDER
+            OrderStatus.NEW_ORDER.name
         )
         arg_with_method_was_called = (
             self.kitchen_simulator.order_manager._mock_mock_calls[1][1]
         )
-        self.assertEqual(arg_with_method_was_called[0].status, OrderStatus.CANCELLED)
+        self.assertEqual(arg_with_method_was_called[0].status, OrderStatus.CANCELLED.name)
 
     @mock.patch(
         "src.core.engine.processors.kitchen_simulator.compute_order_estimated_time",
@@ -127,7 +127,7 @@ class KitchenSimulatorTest(unittest.TestCase):
         )
         self.kitchen_simulator.order_controller.get_order_ingredients_by_order_id.return_value = [
             build_product_ingredient(
-                product_ingredient_id=1, quantity=1, ingredient_type=CookingType.FRYING
+                product_ingredient_id=1, quantity=1, cooking_type=CookingType.FRYING.name
             )
         ]
         order_1 = build_order(order_id=1, status=OrderStatus.IN_PROCESS)
@@ -145,7 +145,7 @@ class KitchenSimulatorTest(unittest.TestCase):
         )
         self.kitchen_simulator.process_orders_in_process()
         self.kitchen_simulator.order_manager.get_queue_from_status.assert_called_with(
-            OrderStatus.IN_PROCESS
+            OrderStatus.IN_PROCESS.name
         )
         self.kitchen_simulator.order_controller.get_by_id.assert_called_with(order_1.id)
         self.kitchen_simulator.order_status_history_controller.get_last_status_history_by_order_id.assert_called_with(
@@ -155,13 +155,13 @@ class KitchenSimulatorTest(unittest.TestCase):
         arg_with_method_was_call = (
             self.kitchen_simulator.order_manager.add_to_queue.mock_calls[0][1]
         )
-        self.assertEqual(arg_with_method_was_call[0].status, OrderStatus.COMPLETED)
+        self.assertEqual(arg_with_method_was_call[0].status, OrderStatus.COMPLETED.name)
         mocked_compute_order_estimated_time.assert_called_with(
             [
                 build_product_ingredient(
                     product_ingredient_id=1,
                     quantity=1,
-                    ingredient_type=CookingType.FRYING,
+                    cooking_type=CookingType.FRYING.name,
                 )
             ],
             build_chef(chef_id=1),

--- a/src/tests/core/order_manager_test.py
+++ b/src/tests/core/order_manager_test.py
@@ -10,39 +10,39 @@ class OrderManagerTestCase(unittest.TestCase):
         self.order_manager = OrderManager()
 
     def test_get_from_order_storage(self):
-        order_1 = build_order(order_id=1, status=OrderStatus.NEW_ORDER)
-        order_2 = build_order(order_id=2, status=OrderStatus.NEW_ORDER)
-        order_3 = build_order(order_id=3, status=OrderStatus.NEW_ORDER)
+        order_1 = build_order(order_id=1, status=OrderStatus.NEW_ORDER.name)
+        order_2 = build_order(order_id=2, status=OrderStatus.NEW_ORDER.name)
+        order_3 = build_order(order_id=3, status=OrderStatus.NEW_ORDER.name)
 
         self.order_manager.add_to_queue(order_3)
         self.order_manager.add_to_queue(order_1)
         self.order_manager.add_to_queue(order_2)
 
         order_id_pulled_with_id_priority = self.order_manager.get_queue_from_status(
-            OrderStatus.NEW_ORDER
+            OrderStatus.NEW_ORDER.name
         )
         self.assertEqual(order_id_pulled_with_id_priority, order_1.id)
 
     def test_get_queue_size(self):
-        order_1 = build_order(order_id=1, status=OrderStatus.NEW_ORDER)
-        order_2 = build_order(order_id=2, status=OrderStatus.NEW_ORDER)
+        order_1 = build_order(order_id=1, status=OrderStatus.NEW_ORDER.name)
+        order_2 = build_order(order_id=2, status=OrderStatus.NEW_ORDER.name)
 
         self.order_manager.add_to_queue(order_1)
         self.order_manager.add_to_queue(order_2)
 
         order_placed_storage_size = self.order_manager.get_queue_size(
-            OrderStatus.NEW_ORDER
+            OrderStatus.NEW_ORDER.name
         )
         self.assertEqual(order_placed_storage_size, 2)
 
     def test_get_queue_status_empty(self):
-        queue_status = self.order_manager.is_order_queue_empty(OrderStatus.NEW_ORDER)
+        queue_status = self.order_manager.is_order_queue_empty(OrderStatus.NEW_ORDER.name)
         self.assertTrue(queue_status)
 
     def test_clean_queues_with_full_storage(self):
-        order_1 = build_order(order_id=1, status=OrderStatus.COMPLETED)
-        order_2 = build_order(order_id=2, status=OrderStatus.COMPLETED)
-        order_3 = build_order(order_id=3, status=OrderStatus.COMPLETED)
+        order_1 = build_order(order_id=1, status=OrderStatus.COMPLETED.name)
+        order_2 = build_order(order_id=2, status=OrderStatus.COMPLETED.name)
+        order_3 = build_order(order_id=3, status=OrderStatus.COMPLETED.name)
 
         order_manager = OrderManager()
         order_manager.add_to_queue(order_1)
@@ -50,6 +50,6 @@ class OrderManagerTestCase(unittest.TestCase):
         order_manager.add_to_queue(order_3)
         order_manager.clean_queues_with_full_storage(limit_value_before_clean=2)
         completed_queue_size_after_clean = order_manager.get_queue_size(
-            OrderStatus.COMPLETED
+            OrderStatus.COMPLETED.name
         )
         self.assertEqual(completed_queue_size_after_clean, 0)

--- a/src/tests/utils/fixtures/product_ingredient_fixture.py
+++ b/src/tests/utils/fixtures/product_ingredient_fixture.py
@@ -7,7 +7,7 @@ def build_product_ingredient(
     product_id=None,
     ingredient_id=None,
     quantity=None,
-    ingredient_type=None,
+    cooking_type=None,
     entity_status=None,
     create_by=None,
 ):
@@ -16,7 +16,7 @@ def build_product_ingredient(
     product_ingredient.product_id = product_id
     product_ingredient.ingredient_id = ingredient_id
     product_ingredient.quantity = quantity
-    product_ingredient.ingredient_type = ingredient_type
+    product_ingredient.cooking_type = cooking_type
     product_ingredient.entity_status = entity_status or Status.ACTIVE
     product_ingredient.create_by = create_by
     return product_ingredient

--- a/src/tests/utils/order_util_test.py
+++ b/src/tests/utils/order_util_test.py
@@ -92,10 +92,10 @@ class TestOrderUtil(unittest.TestCase):
         chef_1 = build_chef(chef_id=1, chef_skills=2)
         order_ingredients_list = [
             build_product_ingredient(
-                product_ingredient_id=1, ingredient_type=CookingType.FRYING, quantity=2
+                product_ingredient_id=1, cooking_type=CookingType.FRYING.name, quantity=2
             ),
             build_product_ingredient(
-                product_ingredient_id=2, ingredient_type=CookingType.BAKING, quantity=2
+                product_ingredient_id=2, cooking_type=CookingType.BAKING.name, quantity=2
             ),
         ]
         preparation_time = compute_order_estimated_time(order_ingredients_list, chef_1)

--- a/src/utils/order_util.py
+++ b/src/utils/order_util.py
@@ -1,6 +1,8 @@
 # reducer function to get assigned chef map
 from functools import reduce
 
+from src.constants.cooking_type import CookingType
+
 
 def array_chef_to_chef_assigned_orders_map_reducer(
     chef_with_assigned_orders_result, chef_id, orders
@@ -88,7 +90,7 @@ def compute_order_estimated_time(order_ingredient_list, chef):
 
     order_estimated_time = reduce(
         lambda estimated_time_result, product_ingredient: estimated_time_result
-        + (product_ingredient.ingredient_type.value * product_ingredient.quantity),
+        + (CookingType[product_ingredient.cooking_type].value * product_ingredient.quantity),
         order_ingredient_list,
         0,
     )


### PR DESCRIPTION
* adding init method to abstract_processor as abstract method to be inherited by class to inherit abstract processor class
* adding init method inside kitchen simulator with init_queue_before_start_ks method to add the orders and they status to the differents queue
* refactoring seeder to add order status histories of orders in the moment when orders were create.
* refactoring order manager to use enum.name instead whole enum to match with status(string) using in the orders inside db
* fixing order manager test to match enum.name
* adding mocking .init method to abstract processor test
* fixing order status in kitchen simulator test to match order status using enum.name
* refactoring orter util method compute order estimated time to match with cooking type (string)