### PR TITLE
refactor order status history repository

### DIFF
--- a/src/core/sqlalchemy_config.py
+++ b/src/core/sqlalchemy_config.py
@@ -6,6 +6,6 @@ from sqlalchemy.orm import sessionmaker
 
 def create_session():
     engine = create_engine("postgresql://postgres:1234@localhost/ea_restaurant")
-    session_creation = sessionmaker(engine)
+    session_creation = sessionmaker(bind=engine, expire_on_commit=False, autocommit=True)
     session = session_creation()
     return session

--- a/src/tests/lib/repositories/sqlalchemy_mock_builder.py
+++ b/src/tests/lib/repositories/sqlalchemy_mock_builder.py
@@ -102,6 +102,15 @@ class QueryOperationsMock:
         self.current_mock = mocked_join.join
         return self
 
+    def order_by(self, return_value=None, side_effect_fn=None):
+        mocked_order_by = mock.Mock()
+        self.current_mock.return_value = mocked_order_by
+        mocked_order_by.order_by = mock.Mock()
+        mocked_order_by.order_by.return_value = return_value or mocked_order_by.order_by.return_value
+        mocked_order_by.order_by.side_effect = side_effect_fn or mocked_order_by.order_by.side_effect
+        self.current_mock = mocked_order_by.order_by
+        return self
+
     def get_mocked_query(self):
         return self.mocked_query
 

--- a/src/utils/order_util.py
+++ b/src/utils/order_util.py
@@ -95,4 +95,4 @@ def compute_order_estimated_time(order_ingredient_list, chef):
         0,
     )
 
-    return order_estimated_time / chef.chef_skills
+    return order_estimated_time / chef.skill


### PR DESCRIPTION
* fixing method set_next_order_status_history, before fix method open to session.begin() because called an update method inside session.begin.
* adding autocommit=True to sqlalchemy session config
* fixing order status history repository test to match fixed set_next_order_status_history_method
* adding order_by_mock to sqlalchemy_mock_builder