### PR TITLE
adding migration to add initial data to mongodb

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -2,7 +2,7 @@
 
 [alembic]
 # path to migration scripts
-script_location = migrations
+script_location = src/migrations
 
 # template used to generate migration file names; The default value is %%(rev)s_%%(slug)s
 # Uncomment the line below if you want the files to be prepended with date and time

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,4 @@ typing_extensions==4.2.0
 userpath==1.7.0
 wincertstore==0.2
 wrapt==1.14.0
+mongoengine==0.24.2

--- a/src/core/mongo_engine_config.py
+++ b/src/core/mongo_engine_config.py
@@ -1,0 +1,6 @@
+from mongoengine import connect
+
+
+def mongo_engine_connexion():
+
+    connect(db="ea_restaurant", host="localhost", port=27017)

--- a/src/lib/entities/mongo_engine_odm_mapping.py
+++ b/src/lib/entities/mongo_engine_odm_mapping.py
@@ -1,0 +1,23 @@
+from mongoengine import Document, IntField, DateTimeField, StringField
+
+
+class BaseEntity(Document):
+    entity_status = StringField()
+    created_date = DateTimeField()
+    updated_date = DateTimeField()
+    created_by = IntField()
+    updated_by = IntField()
+
+    meta = {"allow_inheritance": True, "abstract": True}
+
+
+class OrderStatusHistory(BaseEntity):
+
+    _id = IntField(required=True)
+    order_id = IntField(required=True)
+    from_time = DateTimeField()
+    to_time = DateTimeField()
+    from_status = StringField()
+    to_status = StringField()
+
+    meta = {"collection": "order_status_histories"}

--- a/src/migrations/versions/da1fd865c698_mongo_initial_data.py
+++ b/src/migrations/versions/da1fd865c698_mongo_initial_data.py
@@ -1,0 +1,50 @@
+"""mongo-initial-data
+
+Revision ID: da1fd865c698
+Revises: e96d49093b33
+Create Date: 2022-09-14 09:54:00.367087
+
+"""
+from alembic import op
+from sqlalchemy.orm.session import Session
+from src.constants.audit import Status
+from src.core.mongo_engine_config import mongo_engine_connexion
+
+# revision identifiers, used by Alembic.
+from src.lib.entities import sqlalchemy_orm_mapping
+from src.lib.entities import mongo_engine_odm_mapping
+
+revision = "da1fd865c698"
+down_revision = "e96d49093b33"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    mongo_engine_connexion()
+
+    session = Session(bind=op.get_bind())
+
+    order_status_histories = session.query(
+        sqlalchemy_orm_mapping.OrderStatusHistory
+    ).filter(
+        sqlalchemy_orm_mapping.OrderStatusHistory.entity_status == Status.ACTIVE.value
+    )
+    for order_status_history in list(order_status_histories):
+        mongo_order_status_history = mongo_engine_odm_mapping.OrderStatusHistory()
+        mongo_order_status_history._id = order_status_history.id
+        mongo_order_status_history.order_id = order_status_history.id
+        mongo_order_status_history.from_status = order_status_history.from_status
+        mongo_order_status_history.to_status = order_status_history.to_status
+        mongo_order_status_history.from_time = order_status_history.from_time
+        mongo_order_status_history.to_time = order_status_history.to_time
+        mongo_order_status_history.entity_status = order_status_history.entity_status
+        mongo_order_status_history.created_by = order_status_history.created_by
+        mongo_order_status_history.created_date = order_status_history.created_date
+        mongo_order_status_history.updated_by = order_status_history.updated_by
+        mongo_order_status_history.updated_date = order_status_history.updated_date
+        mongo_order_status_history.save()
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
* Adding migration to add initial data to order status histories collection in mogodb database, as initial orders are created at
postgresql running de seeder, the initial data of order status histories of those orders need to be send to mongodb as order status histories repository will be manage by mongodb collections.