### PR TITLE
Feature: adding method to update etl status in mongo

### DIFF
--- a/src/tests/lib/repositories/impl_no_sql/order_status_history_impl_test.py
+++ b/src/tests/lib/repositories/impl_no_sql/order_status_history_impl_test.py
@@ -133,3 +133,19 @@ class OrderStatusHistoryRepositoryImplTest(MongoEngineBaseRepositoryTestCase):
         )
         mocked_save.assert_called_with()
         self.assertEqual(len(mocked_save.mock_calls), 3)
+
+    @mock.patch("pymongo.collection.Collection.update_many")
+    def test_update_batch_processed(self, mocked_update_many):
+        postgresql_ids = [1, 2]
+
+        self.order_status_history_repository.update_batch_processed(postgresql_ids)
+
+        self.assertEqual(
+            mocked_update_many.mock_calls[0].args[0],
+            {"_id": {"$in": postgresql_ids}},
+        )
+
+        self.assertEqual(
+            mocked_update_many.mock_calls[0].args[1],
+            {"$set": {"etl_status": "PROCESSED"}},
+        )

--- a/src/tests/lib/repositories/impl_v2/order_status_history_repository_impl_test.py
+++ b/src/tests/lib/repositories/impl_v2/order_status_history_repository_impl_test.py
@@ -273,5 +273,5 @@ class OrderStatusHistoryRepositoryImplTestCase(SqlAlchemyBaseRepositoryTestCase)
 
         self.assertEqual(
             self.mocked_sqlalchemy_session.mock_calls[3].args[1],
-            {"order_status_history_uuids": mongo_uuids},
+            {"order_status_history_ids": mongo_uuids},
         )


### PR DESCRIPTION
* Adding method to update etl status in mongo db documents using pymongo instead mongoengine.