### PR TITLE
Refactor: client and user validation to raise error when wrong credentials

### DIFF
--- a/src/lib/repositories/impl_v2/oauth2_repository_impl.py
+++ b/src/lib/repositories/impl_v2/oauth2_repository_impl.py
@@ -127,17 +127,21 @@ class Oauth2RepositoryImpl:
     def _validate_client_credentials(self, client_id, client_secret):
         client = self._get_client_by_client_id(client_id)
 
-        if not bcrypt.checkpw(
-            client_secret.encode("utf-8"), client.client_secret.encode("utf-8")
-        ):
-            raise BcryptException("Invalid Client Secret")
+        if client:
+
+            if bcrypt.checkpw(client_secret.encode("utf-8"), client.client_secret.encode("utf-8")) is True:
+                return
+
+        raise BcryptException("Invalid credentials")
 
     def _validate_user_credentials(self, client, username, password):
         user = self._get_user_by_username(username)
 
-        if not bcrypt.checkpw(password.encode("utf-8"), user.password.encode("utf-8")):
-            raise BcryptException("Invalid User Password")
-        self._get_client_user_by_username_and_app_client_id(username, client.id)
+        if user:
+            if bcrypt.checkpw(password.encode("utf-8"), user.password.encode("utf-8")) is True:
+                return
+            self._get_client_user_by_username_and_app_client_id(username, client.id)
+        raise BcryptException("Invalid credentials")
 
     def _get_user_by_username(self, username):
         with self.engine.begin() as conn:

--- a/src/tests/utils/fixtures/oauth2_fixture.py
+++ b/src/tests/utils/fixtures/oauth2_fixture.py
@@ -75,7 +75,7 @@ def build_user(id=None, name=None, last_name=None, username=None, password=None,
     user.username = username or "juperez"
     password_encrypted = encrypt_password(password or "1234abcd")
     user.password = password_encrypted
-    user.roles = roles or ["administrator"]
+    user.roles = roles or "administrator"
     return user
 
 

--- a/src/utils/oauth2_util.py
+++ b/src/utils/oauth2_util.py
@@ -350,13 +350,13 @@ def build_client_credentials_refresh_token(client, scopes, secret_key):
 
 
 def build_user_credential_access_token(user, client, secret_key, scopes):
-    roles = user.roles
+
     token = jwt.encode(
         {
             "username": user.username,
             "name": user.name,
             "last_name": user.last_name,
-            "roles": roles.split(","),
+            "roles": user.roles.split(","),
             "scopes": scopes,
             "exp": datetime.utcnow()
             + timedelta(seconds=client.access_token_expiration_time),
@@ -369,13 +369,13 @@ def build_user_credential_access_token(user, client, secret_key, scopes):
 
 
 def build_user_credential_refresh_token(user, client, secret_key, scopes):
-    roles = user.roles
+
     token = jwt.encode(
         {
             "username": user.username,
             "name": user.name,
             "last_name": user.last_name,
-            "roles": roles.split(","),
+            "roles": user.roles.split(","),
             "scopes": scopes,
             "exp": datetime.utcnow()
             + timedelta(seconds=client.refresh_token_expiration_time),


### PR DESCRIPTION
* Refactor client and user validation to include wrong username and wrong client id in the raise exception condition
* adding test to validate the raise exception when username and client id are incorrect.