### PR TITLE
Feature: adding refresh token andpoint and test to java etl grpc client

### DIFF
--- a/src/grpc/clients/ea_restaurant_java_etl_grpc_client.py
+++ b/src/grpc/clients/ea_restaurant_java_etl_grpc_client.py
@@ -12,3 +12,12 @@ class EaRestaurantJavaEtlGrpcClient:
         metadata = (("authorization", basic_token),)
         no_param = java_etl_grpc_client_pb2.NotParametersRequest()
         return self.service_stub.loginClient(no_param, metadata=metadata)
+
+    def refresh_token(self, refresh_token, access_token, client_id, client_secret):
+        refresh_token_request = java_etl_grpc_client_pb2.RefreshTokenRequest(
+            refreshToken=refresh_token,
+            accessToken=access_token,
+            clientId=client_id,
+            clientSecret=client_secret,
+        )
+        return self.service_stub.refreshToken(refresh_token_request)

--- a/src/tests/utils/fixtures/grpc_fixture.py
+++ b/src/tests/utils/fixtures/grpc_fixture.py
@@ -9,3 +9,12 @@ def build_login_client_response():
         scopes="READ",
         clientName="test client",
     )
+
+
+def build_refresh_token_request():
+    return java_etl_grpc_client_pb2.RefreshTokenRequest(
+        refreshToken="test refresh token",
+        accessToken="test access token",
+        clientId="postman001",
+        clientSecret="postmansecret01",
+    )


### PR DESCRIPTION
* Adding refresh token endpoint to `ea_restaurant_java_etl_grpc_client`
* Adding test for refresh token endpoint