### PR TITLE
Refactor: refactoring mongo etls to use method get by servie

### DIFF
--- a/src/core/engine/processors/etl/mongo_order_status_history_distribution_etl.py
+++ b/src/core/engine/processors/etl/mongo_order_status_history_distribution_etl.py
@@ -1,4 +1,4 @@
-from src.constants.etl_status import Service
+from src.constants.etl_status import Service, EtlStatus
 from src.core.engine.processors.etl.abstract_etl_processor import AbstractEtl
 from src.lib.repositories.impl_no_sql.order_status_history_repository_impl import (
     OrderStatusHistoryRepositoryImpl as MongoOrderStatusHistoryRepository,
@@ -27,7 +27,9 @@ class MongoOrderStatusHistoryDistributionEtl(AbstractEtl):
 
         unassigned_order_status_histories_from_mongo = (
             mongo_repository.get_order_status_histories_by_service(
-                Service.UNASSIGNED, limit=UNASSIGNED_ORDER_STATUS_HISTORIES_LIMIT
+                Service.UNASSIGNED,
+                etl_status=EtlStatus.UNPROCESSED,
+                limit=UNASSIGNED_ORDER_STATUS_HISTORIES_LIMIT,
             )
         )
 

--- a/src/core/engine/processors/etl/mongo_to_postgresql_order_status_history_etl.py
+++ b/src/core/engine/processors/etl/mongo_to_postgresql_order_status_history_etl.py
@@ -4,7 +4,11 @@ from src.api.controllers.order_status_history_controller import (
     OrderStatusHistoryController,
 )
 from src.constants.audit import InternalUsers
+from src.constants.etl_status import Service, EtlStatus
 from src.core.engine.processors.etl.abstract_etl_processor import AbstractEtl
+from src.core.engine.processors.etl.mongo_order_status_history_distribution_etl import (
+    UNASSIGNED_ORDER_STATUS_HISTORIES_LIMIT,
+)
 from src.lib.entities.sqlalchemy_orm_mapping import (
     OrderStatusHistory as SqlalchemyOrderStatusHistory,
 )
@@ -44,8 +48,10 @@ class MongoToPostgresqlOrderStatusHistoryEtl(AbstractEtl):
 
     def extract_data(self):
 
-        order_status_histories_from_mongo = (
-            self.mongo_order_status_history_repository.get_unprocessed_order_status_histories()
+        order_status_histories_from_mongo = self.mongo_order_status_history_repository.get_order_status_histories_by_service(
+            Service.PYTHON_ETL,
+            etl_status=EtlStatus.UNPROCESSED,
+            limit=UNASSIGNED_ORDER_STATUS_HISTORIES_LIMIT,
         )
 
         return order_status_histories_from_mongo

--- a/src/lib/repositories/impl_no_sql/order_status_history_repository_impl.py
+++ b/src/lib/repositories/impl_no_sql/order_status_history_repository_impl.py
@@ -130,9 +130,9 @@ class OrderStatusHistoryRepositoryImpl(OrderStatusHistoryRepository):
     def get_last_order_status_histories_by_order_ids(self, order_id):
         pass
 
-    def get_order_status_histories_by_service(self, service, limit):
+    def get_order_status_histories_by_service(self, service, etl_status, limit):
         order_status_histories_by_service = OrderStatusHistory.objects(
-            service=service.value
+            service=service.value, etl_status=etl_status.value
         ).limit(limit)
         return order_status_histories_by_service
 

--- a/src/lib/repositories/order_status_history_repository.py
+++ b/src/lib/repositories/order_status_history_repository.py
@@ -22,5 +22,5 @@ class OrderStatusHistoryRepository(GenericRepository, metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def get_order_status_histories_by_service(self, service, limit):
+    def get_order_status_histories_by_service(self, service, etl_status, limit):
         pass

--- a/src/tests/core/engine/processors/etl/mongo_order_status_history_distribution_etl_test.py
+++ b/src/tests/core/engine/processors/etl/mongo_order_status_history_distribution_etl_test.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest import mock
 
-from src.constants.etl_status import Service
+from src.constants.etl_status import Service, EtlStatus
 from src.core.engine.processors.etl.abstract_etl_processor import AbstractEtl
 from src.core.engine.processors.etl.mongo_order_status_history_distribution_etl import (
     MongoOrderStatusHistoryDistributionEtl,
@@ -45,7 +45,9 @@ class MongoOrderStatusHistoryDistributionEtlTest(MongoEngineBaseRepositoryTestCa
             mongo_order_status_distribution_etl.mongo_order_status_history_repository
         )
         mongo_repository.get_order_status_histories_by_service.assert_called_with(
-            Service.UNASSIGNED, limit=UNASSIGNED_ORDER_STATUS_HISTORIES_LIMIT
+            Service.UNASSIGNED,
+            etl_status=EtlStatus.UNPROCESSED,
+            limit=UNASSIGNED_ORDER_STATUS_HISTORIES_LIMIT,
         )
 
     def test_transform_data_successfully(self):

--- a/src/tests/core/engine/processors/mongo_to_postgres_order_status_history_test.py
+++ b/src/tests/core/engine/processors/mongo_to_postgres_order_status_history_test.py
@@ -1,7 +1,11 @@
 from unittest import mock
 
 from src.constants.audit import InternalUsers
+from src.constants.etl_status import EtlStatus, Service
 from src.core.engine.processors.etl.abstract_etl_processor import AbstractEtl
+from src.core.engine.processors.etl.mongo_order_status_history_distribution_etl import (
+    UNASSIGNED_ORDER_STATUS_HISTORIES_LIMIT,
+)
 from src.core.engine.processors.etl.mongo_to_postgresql_order_status_history_etl import (
     MongoToPostgresqlOrderStatusHistoryEtl,
 )
@@ -44,10 +48,14 @@ class MongoToPostgresOrderStatusHistoryTest(MongoEngineBaseRepositoryTestCase):
 
         etl.start()
         mongo_repository = etl.mongo_order_status_history_repository
-        mongo_repository.get_unprocessed_order_status_histories.assert_called()
+        mongo_repository.get_order_status_histories_by_service.assert_called_with(
+            Service.PYTHON_ETL,
+            etl_status=EtlStatus.UNPROCESSED,
+            limit=UNASSIGNED_ORDER_STATUS_HISTORIES_LIMIT,
+        )
 
     @mock.patch(
-        "src.core.engine.processors.mongo_to_postgresql_order_status_history."
+        "src.core.engine.processors.etl.mongo_to_postgresql_order_status_history_etl."
         + "convert_mongo_order_status_history_to_postgres_order_status_history"
     )
     def test_transform_data_successfully(self, mocked_convert_mongo_to_postgres):
@@ -75,7 +83,7 @@ class MongoToPostgresOrderStatusHistoryTest(MongoEngineBaseRepositoryTestCase):
         )
 
     @mock.patch(
-        "src.core.engine.processors.mongo_to_postgresql_order_status_history."
+        "src.core.engine.processors.etl.mongo_to_postgresql_order_status_history_etl."
         + "update_last_order_status_history"
     )
     def test_load_data_successfully(self, mocked_update_last_order_status_history):


### PR DESCRIPTION
* Refactoring method `get_order_status_histories_by_service` to filter by `Unprocessed`
* Refactoring `mongo to postgresql etl` to use `get order status history by service` filter by `PYTHON_ETL` instead method
`get_unprocessed_order_status_histories`
*refactoring test according to change made in the etls.