### PR TITLE
Refactor: mongo order status histories distribution etl

### DIFF
--- a/src/core/engine/processors/etl/mongo_order_status_history_distribution_etl.py
+++ b/src/core/engine/processors/etl/mongo_order_status_history_distribution_etl.py
@@ -33,11 +33,11 @@ class MongoOrderStatusHistoryDistributionEtl(AbstractEtl):
             )
         )
 
-        return unassigned_order_status_histories_from_mongo
+        return list(unassigned_order_status_histories_from_mongo)
 
     def transform_data(self, extracted_data):
         map_assigned_etl_list = {}
-        half_length = extracted_data // 2
+        half_length = len(extracted_data) // 2
 
         assigned_to_python_etl = extracted_data[:half_length]
 

--- a/src/tests/core/engine/processors/etl/mongo_order_status_history_distribution_etl_test.py
+++ b/src/tests/core/engine/processors/etl/mongo_order_status_history_distribution_etl_test.py
@@ -1,12 +1,16 @@
 import unittest
 from unittest import mock
 
+import mongoengine
+
 from src.constants.etl_status import Service, EtlStatus
+from src.constants.order_status import OrderStatus
 from src.core.engine.processors.etl.abstract_etl_processor import AbstractEtl
 from src.core.engine.processors.etl.mongo_order_status_history_distribution_etl import (
     MongoOrderStatusHistoryDistributionEtl,
     UNASSIGNED_ORDER_STATUS_HISTORIES_LIMIT,
 )
+from src.lib.entities.mongo_engine_odm_mapping import OrderStatusHistory
 from src.tests.lib.repositories.mongo_engine_base_repository_impl_test import (
     MongoEngineBaseRepositoryTestCase,
 )
@@ -111,3 +115,24 @@ class MongoOrderStatusHistoryDistributionEtlTest(MongoEngineBaseRepositoryTestCa
         self.mongo_order_status_distribution_etl.load_data.assert_called_with(
             transformed_data
         )
+
+    def test_extract_data_is_converting_from_queryset_to_list(self):
+        mongo_order_status_history_1 = mongo_build_order_status_history()
+        mongo_order_status_history_2 = mongo_build_order_status_history()
+        mongo_order_status_iterable = iter(
+            [mongo_order_status_history_1, mongo_order_status_history_2]
+        )
+        empty_set = OrderStatusHistory.objects.none()
+        mongo_order_status_distribution_etl = self.mongo_order_status_distribution_etl
+
+        mongo_repository = (
+            mongo_order_status_distribution_etl.mongo_order_status_history_repository
+        )
+        mongo_repository.get_order_status_histories_by_service.return_value = (
+            mongo_order_status_iterable
+        )
+        extracted_data = mongo_order_status_distribution_etl.extract_data()
+        self.assertEqual(
+            extracted_data, [mongo_order_status_history_1, mongo_order_status_history_2]
+        )
+        self.assertEqual(type(extracted_data), list)


### PR DESCRIPTION
* Converting `querySet` into list as query set only can be round once.